### PR TITLE
add polling of status(on or off and brightness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# v1.3.0
+
+## New Features
+
+- Add polling to get light state (on/off) and brightness - Thanks [@pim12345](https://github.com/pim12345)
+
+## Fixes

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -269,19 +269,16 @@ class coloLight(Light, RestoreEntity):
             self._hs_color = last_state.attributes.get("hs_color")
     
     def update(self):
-        try:
-            self._light._sock.sendto(bytes.fromhex("535a303000000000001e000000000000000000000000000000000200000000000000000003020101"), (self._host, self._port))
-            data = self._light._sock.recvfrom(4096)[0]
-            if not data: return
-            if data[40] == 207:#0xcf
-                self._on = True
-            elif data[40] == 206:#0xce
-                self._on = False
-            else:
-                return #if value is not 0xcf(on) or 0xce(off) stop the update then dont change anything
-            self._brightness = (data[41]/100)*255 #data[41] gives back value between 0 and 100, now will scale between 0 and 255
-        except:
-            return #return function if sending or reciving is not successful or timeout of 4 seconds is reached
+        self._light._sock.sendto(bytes.fromhex("535a303000000000001e000000000000000000000000000000000200000000000000000003020101"), (self._host, self._port))
+        data = self._light._sock.recvfrom(4096)[0]
+        if not data: return
+        if data[40] == 207:#0xcf
+            self._on = True
+        elif data[40] == 206:#0xce
+           self._on = False
+        else:
+            return #if value is not 0xcf(on) or 0xce(off) stop the update then dont change anything
+        self._brightness = (data[41]/100)*255 #data[41] gives back value between 0 and 100, now will scale between 0 and 255
 
 class ColourSchemeException(Exception):
     pass

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -282,7 +282,7 @@ class coloLight(Light, RestoreEntity):
                     self._brightness = round(self._light.brightness * 2.55)
 
             except:
-                _LOGGER.error("Error with update status of Cololight")
+                _LOGGER.error("Error with update status of Cololight. Device may be offline.")
         else:
             self._canUpdate = True
 
@@ -472,6 +472,7 @@ class PyCololight:
 
     def _socket_connect(self):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(4)
 
     def _socket_close(self):
         self._sock.close()

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -251,12 +251,10 @@ class coloLight(Light, RestoreEntity):
 
         self._light.on = coverted_brightness
         self._on = True
-        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         self._light.on = 0
         self._on = False
-        self.async_write_ha_state()
 
     async def async_added_to_hass(self):
         """Handle entity about to be added to hass event."""
@@ -268,7 +266,7 @@ class coloLight(Light, RestoreEntity):
             self._brightness = last_state.attributes.get("brightness", 255)
             self._hs_color = last_state.attributes.get("hs_color")
     
-    def update(self):
+    async def async_update(self):
         self._light._sock.sendto(bytes.fromhex("535a303000000000001e000000000000000000000000000000000200000000000000000003020101"), (self._host, self._port))
         data = self._light._sock.recvfrom(4096)[0]
         if not data: return

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -179,11 +179,16 @@ class coloLight(Light, RestoreEntity):
         self._on = False
         self._brightness = 255
         self._hs_color = None
+        self._available = True
         self._canUpdate = True
 
     @property
     def name(self):
         return self._name
+
+    @property
+    def available(self):
+        return self._available
 
     @property
     def icon(self):
@@ -281,8 +286,13 @@ class coloLight(Light, RestoreEntity):
                 if self._on:
                     self._brightness = round(self._light.brightness * 2.55)
 
+                self._available = True
+
+            except TimeoutException:
+                self._available = False
+
             except:
-                _LOGGER.error("Error with update status of Cololight. Device may be offline.")
+                _LOGGER.error("Error with update status of Cololight.")
         else:
             self._canUpdate = True
 
@@ -304,6 +314,10 @@ class ModeExecption(Exception):
 
 
 class DefaultEffectExecption(Exception):
+    pass
+
+
+class TimeoutException(Exception):
     pass
 
 
@@ -485,9 +499,12 @@ class PyCololight:
             self._socket_close()
 
     def _receive(self):
-        data = self._sock.recvfrom(4096)[0]
-        self._socket_close()
-        return data
+        try:
+            data = self._sock.recvfrom(4096)[0]
+            self._socket_close()
+            return data
+        except socket.timeout:
+            raise TimeoutException
 
     def _get_config(self, config_type):
         if config_type == "command":

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -462,7 +462,7 @@ class PyCololight:
         self._colour = None
         self._effect = None
         self._effects = self.DEFAULT_EFFECTS.copy() if default_effects else {}
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock = None
 
     def _switch_count(self):
         if self._count == 1:
@@ -470,11 +470,22 @@ class PyCololight:
         else:
             self._count = 1
 
-    def _send(self, command):
+    def _socket_connect(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def _socket_close(self):
+        self._sock.close()
+
+    def _send(self, command, response=False):
+        self._socket_connect()
         self._sock.sendto(command, (self.host, self.port))
+
+        if not response:
+            self._socket_close()
 
     def _receive(self):
         data = self._sock.recvfrom(4096)[0]
+        self._socket_close()
         return data
 
     def _get_config(self, config_type):
@@ -530,7 +541,8 @@ class PyCololight:
         self._send(
             bytes.fromhex(
                 "535a303000000000001e000000000000000000000000000000000200000000000000000003020101"
-            )
+            ),
+            response=True,
         )
         data = self._receive()
         if not data:

--- a/custom_components/cololight/manifest.json
+++ b/custom_components/cololight/manifest.json
@@ -3,7 +3,7 @@
   "name": "LifeSmart Cololight",
   "config_flow": true,
   "documentation": "https://github.com/BazaJayGee66/homeassistant_cololight",
-  "version": "v1.2.1",
+  "version": "v1.3.0",
   "dependencies": [],
   "codeowners": [],
   "requirements": []


### PR DESCRIPTION
hey BazaJayGree66,

In this PR, I added polling of the status of the cololight (brightness and on/off). I found out by using wireshark and their [razer integration](https://www.razer.com/chroma-workshop#--apps--look--Y29sb2xpZ2h0L2NvbG9saWdodA_-__-_). I have only tested with cololight firmware version of: 5.18.8.9 (I think the newest version) and I don't know if it will work with older versions.(hopefully you can test that). I hope you don't think my code quality is too bad.

Greetings Pim