### PR TITLE
Fix/suspend update task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.2
+
+## Fixes
+
+- Prevent cololight device from locking HA causing lag, when cololight device is unavailable
+
 # v2.0.1
 
 ## Fixes

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -32,7 +32,7 @@ RUN git clone --depth 1 https://github.com/home-assistant/core.git && \
     pip3 install sqlalchemy==1.4.36 fnvhash==0.1.0 lru-dict==1.1.7
 
 # Add pycololight requirement
-RUN pip3 install pycololight==2.0.0
+RUN pip3 install pycololight==2.1.0
 
 WORKDIR /workspaces
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build status](https://badge.buildkite.com/03f664e487145ff4bfd75d66c94e6cecb26051e7479ccb0279.svg)](https://buildkite.com/goodwin/homeassistant-cololight)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+
 # Home Assistant Cololight
 
 The Cololight custom integration allows you to control [LifeSmart Cololight](http://www.cololight.com/) devices in Home Assistnat.
@@ -26,7 +27,7 @@ Supported devices include:
 3. Download `cololight.zip` [release version](https://github.com/BazaJayGee66/homeassistant_cololight/releases), and unzip to custom_components directory
 
 ```sh
-wget https://github.com/BazaJayGee66/homeassistant_cololight/releases/download/v2.0.0/cololight.zip
+wget https://github.com/BazaJayGee66/homeassistant_cololight/releases/download/v2.0.2/cololight.zip
 unzip cololight.zip -d /path/to/custom_components
 rm cololight.zip
 ```

--- a/custom_components/cololight/__init__.py
+++ b/custom_components/cololight/__init__.py
@@ -2,8 +2,7 @@
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.core import callback
-from homeassistant.const import CONF_NAME, Platform
+from homeassistant.const import Platform
 
 DOMAIN = "cololight"
 PLATFORMS = [Platform.LIGHT]

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -145,7 +145,7 @@ class coloLight(Light, RestoreEntity):
         self._brightness = 255
         self._hs_color = None
         self._available = True
-        self._canUpdate = True
+        self._can_update = True
 
     @property
     def name(self):
@@ -232,12 +232,12 @@ class coloLight(Light, RestoreEntity):
 
         self._light.on = coverted_brightness
         self._on = True
-        self._canUpdate = False  # disable next update because light is not switched state to on and will return off state
+        self._can_update = False  # disable next update because light is not switched state to on and will return off state
 
     async def async_turn_off(self, **kwargs):
         self._light.on = 0
         self._on = False
-        self._canUpdate = False  # disable next update because light is not switched state to off and will return on state
+        self._can_update = False  # disable next update because light is not switched state to off and will return on state
 
     async def async_added_to_hass(self):
         """Handle entity about to be added to hass event."""
@@ -250,11 +250,11 @@ class coloLight(Light, RestoreEntity):
             self._hs_color = last_state.attributes.get("hs_color")
 
     async def async_update(self):
-        if self._canUpdate:
-            # after setting the light on or off from home assistant. Home assistant will ask directly for a update, but the light has not switched state so the update function will recive the old state and that trows home assistant off. Now if you turn the light on or off. _canUpdate wil be set to False and the first update will be skipped
+        if self._can_update:
+            # after setting the light on or off from home assistant. Home assistant will ask directly for a update, but the light has not switched state so the update function will recive the old state and that trows home assistant off. Now if you turn the light on or off. _can_update wil be set to False and the first update will be skipped
             await self.hass.async_add_executor_job(self._update_state)
         else:
-            self._canUpdate = True
+            self._can_update = True
 
     def _update_state(self):
         try:

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -252,18 +252,21 @@ class coloLight(Light, RestoreEntity):
     async def async_update(self):
         if self._canUpdate:
             # after setting the light on or off from home assistant. Home assistant will ask directly for a update, but the light has not switched state so the update function will recive the old state and that trows home assistant off. Now if you turn the light on or off. _canUpdate wil be set to False and the first update will be skipped
-            try:
-                self._light.state
-                self._on = self._light.on
-                if self._on:
-                    self._brightness = round(self._light.brightness * 2.55)
-
-                self._available = True
-
-            except UnavailableException:
-                self._available = False
-
-            except:
-                _LOGGER.error("Error with update status of Cololight.")
+            await self.hass.async_add_executor_job(self._update_state)
         else:
             self._canUpdate = True
+
+    def _update_state(self):
+        try:
+            self._light.state
+            self._on = self._light.on
+            if self._on:
+                self._brightness = round(self._light.brightness * 2.55)
+
+            self._available = True
+
+        except UnavailableException:
+            self._available = False
+
+        except:
+            _LOGGER.error("Error with update status of Cololight: %s", self._name)

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -68,7 +68,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
         effects.extend(entry.data["dynamic_effects"])
 
     cololight_light = PyCololight(
-        device=device, host=host, default_effects=False, dynamic_effects=False
+        device=device,
+        host=host,
+        timeout=4,
+        default_effects=False,
+        dynamic_effects=False,
     )
 
     if effects:

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -261,6 +261,7 @@ class coloLight(Light, RestoreEntity):
             self._can_update = True
 
     def _update_state(self):
+        _LOGGER.debug("Updating cololight: %s", self._name)
         try:
             self._light.state
             self._on = self._light.on
@@ -271,6 +272,7 @@ class coloLight(Light, RestoreEntity):
 
         except UnavailableException:
             self._available = False
+            _LOGGER.debug("Cololight unavailable: %s", self._name)
 
         except:
             _LOGGER.error("Error with update status of Cololight: %s", self._name)

--- a/custom_components/cololight/manifest.json
+++ b/custom_components/cololight/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/BazaJayGee66/homeassistant_cololight",
   "issue_tracker": "https://github.com/BazaJayGee66/homeassistant_cololight/issues",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "dependencies": [],
   "iot_class": "local_polling",
   "codeowners": ["@BazaJayGee66"],

--- a/custom_components/cololight/manifest.json
+++ b/custom_components/cololight/manifest.json
@@ -8,5 +8,5 @@
   "dependencies": [],
   "iot_class": "local_polling",
   "codeowners": ["@BazaJayGee66"],
-  "requirements": ["pycololight==2.0.0"]
+  "requirements": ["pycololight==2.1.0"]
 }

--- a/custom_components/tests/test_light.py
+++ b/custom_components/tests/test_light.py
@@ -17,7 +17,6 @@ from homeassistant.components.light import (
     SERVICE_TURN_ON,
 )
 from homeassistant.util.dt import utcnow
-from homeassistant.setup import async_setup_component
 
 LIGHT_1_NAME = "cololight_test"
 ENTITY_1_LIGHT = f"light.{LIGHT_1_NAME}"

--- a/custom_components/tests/test_light.py
+++ b/custom_components/tests/test_light.py
@@ -1,10 +1,12 @@
 import pytest
+from datetime import timedelta
 
 from unittest.mock import patch
+from pycololight import UnavailableException
 
 from tests.conftest import hass, hass_storage, load_registries, hass_fixture_setup
-from tests.common import MockConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from tests.common import MockConfigEntry, async_fire_time_changed
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_EFFECT,
@@ -14,6 +16,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.util.dt import utcnow
 from homeassistant.setup import async_setup_component
 
 LIGHT_1_NAME = "cololight_test"
@@ -235,6 +238,30 @@ async def test_turn_off(mock_send, hass):
     state = hass.states.get(ENTITY_1_LIGHT)
 
     assert state.state == STATE_OFF
+
+
+@patch("homeassistant.components.cololight.light.PyCololight._send")
+async def test_availability(mock_send, hass):
+    """Test the light becomes unavailable when cant be reached."""
+
+    with patch(
+        "homeassistant.components.cololight.light.PyCololight._receive",
+        side_effect=UnavailableException(),
+    ):
+        future = utcnow() + timedelta(minutes=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(ENTITY_1_LIGHT)
+        assert state.state == STATE_UNAVAILABLE
+
+    with patch("homeassistant.components.cololight.light.PyCololight._receive"):
+        future = utcnow() + timedelta(minutes=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(ENTITY_1_LIGHT)
+        assert state.state != STATE_UNAVAILABLE
 
 
 async def test_light_has_effects(hass):


### PR DESCRIPTION
Prevent cololight device from locking HA causing lag, when cololight device is unavailable.

This resolves #30 