### PR TITLE
fix: Replace deprecated light SUPPORT_EFFECT, with new EntityFeature enum

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -17,10 +17,10 @@ try:
     from homeassistant.components.light import (
         SUPPORT_COLOR,
         SUPPORT_BRIGHTNESS,
-        SUPPORT_EFFECT,
         ATTR_HS_COLOR,
         ATTR_BRIGHTNESS,
         ATTR_EFFECT,
+        LightEntityFeature,
         LightEntity as Light,
     )
 # Legacy
@@ -28,10 +28,10 @@ except ImportError:
     from homeassistant.components.light import (
         SUPPORT_COLOR,
         SUPPORT_BRIGHTNESS,
-        SUPPORT_EFFECT,
         ATTR_HS_COLOR,
         ATTR_BRIGHTNESS,
         ATTR_EFFECT,
+        LightEntityFeature,
         Light,
     )
 
@@ -142,7 +142,7 @@ class coloLight(Light, RestoreEntity):
         self._host = host
         self._port = 8900
         self._name = name
-        self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_EFFECT
+        self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR | LightEntityFeature.EFFECT
         self._effect_list = light.effects
         self._effect = None
         self._on = False


### PR DESCRIPTION
Replace deprecated light SUPPORT_EFFECT, with new [EntityFeature enum](https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/)

> As of Home Assistant Core 2024.1, all usage of magic numbers for supported features is deprecated, and each entity platform has provided an EntityFeature enum to replace them.

This resolves https://github.com/BazaJayGee66/homeassistant_cololight/issues/37