### PR TITLE
fix: Replace deprecated light SUPPORT_COLOR, with new ColorMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.4
+
+## Fixes
+
+- Replace deprecated light SUPPORT_COLOR, with new ColorMode ([#40](https://github.com/BazaJayGee66/homeassistant_cololight/pull/40))
+
 # v2.0.3
 
 ## Fixes

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,7 +29,7 @@ RUN git clone --depth 1 https://github.com/home-assistant/core.git && \
     pip3 uninstall -y typing && \
     core/script/setup && \
     pip3 install -r core/requirements.txt && \
-    pip3 install sqlalchemy==1.4.36 fnvhash==0.1.0 lru-dict==1.1.7
+    pip3 install sqlalchemy==2.0.28 lru-dict==1.3.0
 
 # Add pycololight requirement
 RUN pip3 install pycololight==2.1.0

--- a/custom_components/cololight/manifest.json
+++ b/custom_components/cololight/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/BazaJayGee66/homeassistant_cololight",
   "issue_tracker": "https://github.com/BazaJayGee66/homeassistant_cololight/issues",
-  "version": "v2.0.2",
+  "version": "v2.0.4",
   "dependencies": [],
   "iot_class": "local_polling",
   "codeowners": ["@BazaJayGee66"],


### PR DESCRIPTION
Replace deprecated light SUPPORT_COLOR, with new [ColorMode](https://developers.home-assistant.io/blog/2024/02/12/light-color-mode-mandatory/)

> Light entities are now required to set the supported_color_modes and color_mode properties, and a warning will be logged asking users to report an issue if that's not done.

This is also a temporary resolve for https://github.com/BazaJayGee66/homeassistant_cololight/issues/39