### PR TITLE
fix: Set color_mode to brightness, when an effect is set

### DIFF
--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -186,7 +186,10 @@ class coloLight(Light, RestoreEntity):
 
     @property
     def color_mode(self) -> ColorMode:
-        return ColorMode.HS
+        if self._effect:
+            return ColorMode.BRIGHTNESS
+        else:
+            return ColorMode.HS
 
     @property
     def effect_list(self):

--- a/custom_components/tests/test_light.py
+++ b/custom_components/tests/test_light.py
@@ -165,6 +165,7 @@ async def test_turn_on(mock_send, hass):
     state = hass.states.get(ENTITY_1_LIGHT)
 
     assert state.state == STATE_ON
+    assert state.attributes.get("color_mode") == "hs"
     assert state.attributes.get(ATTR_BRIGHTNESS) == 255
 
 
@@ -182,6 +183,7 @@ async def test_turn_on_with_brightness(mock_send, hass):
     state = hass.states.get(ENTITY_1_LIGHT)
 
     assert state.state == STATE_ON
+    assert state.attributes.get("color_mode") == "hs"
     assert state.attributes.get(ATTR_BRIGHTNESS) == 60
 
 
@@ -199,6 +201,7 @@ async def test_turn_on_with_effect(mock_send, hass):
     state = hass.states.get(ENTITY_1_LIGHT)
 
     assert state.state == STATE_ON
+    assert state.attributes.get("color_mode") == "brightness"
     assert state.attributes.get(ATTR_BRIGHTNESS) == 60
     assert state.attributes.get(ATTR_EFFECT) == "Sunrise"
 
@@ -219,6 +222,7 @@ async def test_turn_on_with_colour(mock_send, hass):
     assert mock_send.call_count == 2
 
     assert state.state == STATE_ON
+    assert state.attributes.get("color_mode") == "hs"
     assert state.attributes.get(ATTR_BRIGHTNESS) == 60
     assert state.attributes.get(ATTR_HS_COLOR) == (300, 50)
 


### PR DESCRIPTION
A per the documentation for setting [Color Mode when rendering effects ](https://developers.home-assistant.io/docs/core/entity/light/#color-mode-when-rendering-effects), the Color Mode will be set to `brightness` when an effect is set, otherwise the Color Mode will be set to `hs`.

This was preventing using effects as part of Home Assistant scenes.



This resolves #43 