### PR TITLE
fix: Remove deprecated alias HomeAssistantType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.7
+
+## Fixes
+
+- Remove deprecated alias HomeAssistantType ([#45](https://github.com/BazaJayGee66/homeassistant_cololight/pull/45))
+
 # v2.0.6
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supported devices include:
 3. Download `cololight.zip` [release version](https://github.com/BazaJayGee66/homeassistant_cololight/releases), and unzip to custom_components directory
 
 ```sh
-wget https://github.com/BazaJayGee66/homeassistant_cololight/releases/download/v2.0.2/cololight.zip
+wget https://github.com/BazaJayGee66/homeassistant_cololight/releases/download/v2.0.7/cololight.zip
 unzip cololight.zip -d /path/to/custom_components
 rm cololight.zip
 ```

--- a/custom_components/cololight/__init__.py
+++ b/custom_components/cololight/__init__.py
@@ -1,7 +1,7 @@
 """ cololight """
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.const import Platform
 
 DOMAIN = "cololight"
@@ -13,7 +13,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Load the saved entities."""
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
@@ -23,7 +23,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass, entry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
 
     unload_ok = await hass.config_entries.async_forward_entry_unload(
@@ -35,6 +35,6 @@ async def async_unload_entry(hass, entry):
     return unload_ok
 
 
-async def update_listener(hass, entry):
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/cololight/manifest.json
+++ b/custom_components/cololight/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/BazaJayGee66/homeassistant_cololight",
   "issue_tracker": "https://github.com/BazaJayGee66/homeassistant_cololight/issues",
-  "version": "v2.0.6",
+  "version": "v2.0.7",
   "dependencies": [],
   "iot_class": "local_polling",
   "codeowners": ["@BazaJayGee66"],


### PR DESCRIPTION
Remove deprecated alias HomeAssistantType:

> HomeAssistantType was used from cololight, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.HomeAssistant instead, please report it to the author of the 'cololight' custom integration